### PR TITLE
Generate a new dummy node for each test

### DIFF
--- a/stackhpc_ipa_hardware_managers/tests/unit/test_system_bios.py
+++ b/stackhpc_ipa_hardware_managers/tests/unit/test_system_bios.py
@@ -21,6 +21,7 @@ import mock
 
 from stackhpc_ipa_hardware_managers import system_bios
 
+
 def get_dummy_node_info():
     return {
         'extra': {

--- a/stackhpc_ipa_hardware_managers/tests/unit/test_system_bios.py
+++ b/stackhpc_ipa_hardware_managers/tests/unit/test_system_bios.py
@@ -21,22 +21,23 @@ import mock
 
 from stackhpc_ipa_hardware_managers import system_bios
 
-_DUMMY_NODE_INFO = {
-    'extra': {
-        'system_vendor': {
-            'product_name': 'PowerEdge R630',
-            'manufacturer': 'Dell Inc.',
-            'bios_version': '2.3.4'
+def get_dummy_node_info():
+    return {
+        'extra': {
+            'system_vendor': {
+                'product_name': 'PowerEdge R630',
+                'manufacturer': 'Dell Inc.',
+                'bios_version': '2.3.4'
+            }
         }
     }
-}
 
 
 class TestSystemBiosManager(unittest.TestCase):
 
     def setUp(self):
         self.manager = system_bios.SystemBiosHardwareManager()
-        self.node = dict(_DUMMY_NODE_INFO)
+        self.node = get_dummy_node_info()
 
     def test_evaluate_hardware_support(self):
         actual = self.manager.evaluate_hardware_support()


### PR DESCRIPTION
Previously the dummy node was being reused without using a deep copy. Some
tests were modifying the dictionary. This caused tests to fail if they were run
in same worker process.

The behaviour could be triggered when running the test suite with the serial flag
or when the number of tests was greater than the number of installed processors
(default behaviour is one worker process per cpu).

A new data structure is now created for each test. This fixes issue #3.